### PR TITLE
[fix]不同的url下的video，手势调节音量都会从最大音量开始调节

### DIFF
--- a/LLVideoPlayer/LLVideoPlayer.m
+++ b/LLVideoPlayer/LLVideoPlayer.m
@@ -346,6 +346,7 @@ typedef void (^VoidBlock) (void);
         _avPlayer = avPlayer;
         if (avPlayer) {
             __weak __typeof(self) weakSelf = self;
+            avPlayer.volume = [AVAudioSession sharedInstance].outputVolume;
             [avPlayer addObserver:self forKeyPath:@"status" options:0 context:nil];
             self.avTimeObserver = [avPlayer addPeriodicTimeObserverForInterval:CMTimeMake(1, 1) queue:NULL usingBlock:^(CMTime time) {
                 [weakSelf periodicTimeObserver:time];


### PR DESCRIPTION
在url1对应的video中将音量跳到最低，跑到另一个url下的video，同样手势调节音量，发现还是从最大音量开始往下调节。